### PR TITLE
fix: allow specifying string encoding

### DIFF
--- a/lib/DataTypes.js
+++ b/lib/DataTypes.js
@@ -481,7 +481,7 @@ const DataTypes = {
   double      :               new DataType(58 , 'double'       , 8   , doubleToBuf           , doubleFromBuf               ),
 
   octstr      :               new DataType(65 , 'octstr'       , -1  , bufferToBuf           , bufferFromBuf               ),
-  string      :               new DataType(66 , 'string'       , -1  , stringToBuf       , stringFromBuf           ),
+  string      :               new DataType(66 , 'string'       , -1  , stringToBuf           , stringFromBuf               ),
 // octstr16    :               new DataType(67 , 'octstr16'     , -2  , ),
 // string16    :               new DataType(68 , 'string16'     , -2  , ),
 

--- a/lib/DataTypes.js
+++ b/lib/DataTypes.js
@@ -289,26 +289,30 @@ function enumFromBuf(buf, i) {
   return Object.keys(this.args[0]).find(k => this.args[0][k] === val);
 }
 
-function utf8StringToBuf(buf, v, i) {
-  v = Buffer.from(String(v), 'utf8');
+function stringToBuf(buf, v, i, { stringEncoding = 'utf8' } = {}) {
+  v = Buffer.from(String(v), stringEncoding);
   const length = Math.abs(this.length);
 
   i = buf.writeUIntLE(v.length, i, length);
   return v.copy(buf, i) + length;
 }
 
-function utf8StringFromBuf(buf, i, returnLength) {
+function stringFromBuf(buf, i, returnLength, { stringEncoding } = {}) {
   i = i || 0;
   let length = Math.abs(this.length);
   const size = buf.readUIntLE(i, length);
   const result = buf.slice(i + length, i + length + size);
   length += result.length;
 
-  let parsedResult = result.toString('utf8');
-  parsedResult = parsedResult.split('\u0000')[0]; // Remove everything after string terminator
-  // eslint-disable-next-line no-control-regex
-  parsedResult = parsedResult.replace(/[\u0000-\u001F](\[(B|C|D|A))?/g, ''); // Replace remaining
-  parsedResult = parsedResult.trim(); // Trim excessive white space
+  let parsedResult = result.toString(stringEncoding || 'utf8');
+
+  // legacy behaviour, if no stringEncoding is specified we "clean" invalid bytes from the result
+  if (!stringEncoding) {
+    parsedResult = parsedResult.split('\u0000')[0]; // Remove everything after string terminator
+    // eslint-disable-next-line no-control-regex
+    parsedResult = parsedResult.replace(/[\u0000-\u001F](\[(B|C|D|A))?/g, ''); // Replace remaining
+    parsedResult = parsedResult.trim(); // Trim excessive white space
+  }
 
   if (returnLength) {
     return {
@@ -477,7 +481,7 @@ const DataTypes = {
   double      :               new DataType(58 , 'double'       , 8   , doubleToBuf           , doubleFromBuf               ),
 
   octstr      :               new DataType(65 , 'octstr'       , -1  , bufferToBuf           , bufferFromBuf               ),
-  string      :               new DataType(66 , 'string'       , -1  , utf8StringToBuf       , utf8StringFromBuf           ),
+  string      :               new DataType(66 , 'string'       , -1  , stringToBuf       , stringFromBuf           ),
 // octstr16    :               new DataType(67 , 'octstr16'     , -2  , ),
 // string16    :               new DataType(68 , 'string16'     , -2  , ),
 

--- a/lib/DataTypes.js
+++ b/lib/DataTypes.js
@@ -228,7 +228,7 @@ function bufferFromBuf(buf, i, returnLength) {
 }
 
 
-function arrayToBuf(buf, v, i) {
+function arrayToBuf(buf, v, i, options) {
   i = i || 0;
   v = typeof v !== 'undefined' ? v : [];
   const [Type] = this.args;
@@ -240,7 +240,7 @@ function arrayToBuf(buf, v, i) {
   }
   // eslint-disable-next-line guard-for-in,no-restricted-syntax
   for (const j in v) {
-    const res = Type.toBuffer(buf, v[j], i + size);
+    const res = Type.toBuffer(buf, v[j], i + size, options);
     if (Type.length > 0) size += Type.length;
     else if (Buffer.isBuffer(res)) size += res.length;
     else size += res;
@@ -248,7 +248,7 @@ function arrayToBuf(buf, v, i) {
   return size;
 }
 
-function arrayFromBuf(buf, i, returnLength) {
+function arrayFromBuf(buf, i, returnLength, options) {
   i = i || 0;
   const [Type] = this.args;
   const countSize = Math.abs(this.length);
@@ -258,7 +258,7 @@ function arrayFromBuf(buf, i, returnLength) {
   let length = countSize;
   const res = [];
   while (i + length < buf.length && res.length < count) {
-    const entry = Type.fromBuffer(buf, i + length, true);
+    const entry = Type.fromBuffer(buf, i + length, true, options);
     if (Type.length > 0) {
       res.push(entry);
       length += Type.length;

--- a/lib/Struct.js
+++ b/lib/Struct.js
@@ -49,18 +49,18 @@ function Struct(name, defs) {
         }, {}));
       }
 
-      static fromBuffer(buf, i, returnLength) {
+      static fromBuffer(buf, i, returnLength, options) {
         i = i || 0;
         let length = 0;
         const result = new this();
         // eslint-disable-next-line no-restricted-syntax
         for (const p in defs) {
           if (defs[p].length > 0) {
-            result[p] = defs[p].fromBuffer(buf, i + length, false);
+            result[p] = defs[p].fromBuffer(buf, i + length, false, options);
             length += defs[p].length;
           } else {
             const entry = defs[p]
-              .fromBuffer(buf.slice(i, i + buf.length - (size - length)), length, true);
+              .fromBuffer(buf.slice(i, i + buf.length - (size - length)), length, true, options);
             result[p] = entry.result;
             length += entry.length;
           }
@@ -84,12 +84,12 @@ function Struct(name, defs) {
         return result;
       }
 
-      static toBuffer(buf, v, i) {
+      static toBuffer(buf, v, i, options) {
         if (!(v instanceof this.constructor)) v = new this(v);
-        return v.toBuffer(buf, i);
+        return v.toBuffer(buf, i, options);
       }
 
-      toBuffer(buf, i) {
+      toBuffer(buf, i, options) {
         let length = 0;
         i = i || 0;
 
@@ -105,10 +105,10 @@ function Struct(name, defs) {
           // eslint-disable-next-line no-shadow
           let varsize = defs[p].length;
           if (defs[p].length <= 0) {
-            const rBuf = defs[p].toBuffer(buf, this[p], i + length);
+            const rBuf = defs[p].toBuffer(buf, this[p], i + length, options);
             // eslint-disable-next-line no-nested-ternary
             varsize = Number.isFinite(rBuf) ? rBuf : Buffer.isBuffer(rBuf) ? rBuf.length : 0;
-          } else defs[p].toBuffer(buf, this[p], i + length);
+          } else defs[p].toBuffer(buf, this[p], i + length, options);
 
           length += varsize;
         }


### PR DESCRIPTION
I think this PR is a backwards compatible step towards fixing the issue ted is encountering with some attributes.
This allows you to specify options when calling `fromBuffer` and `toBuffer`, if options are passed to a `Struct#fromBuffer` / `Struct#toBuffer` they will be passed down to all `DataType`'s. Support for passing a `stringEncoding` would also need to be added to node-zigbee-clusters, unsure what that would look like so don't merge this until we confirm this is going to work.