### PR TITLE
Fix max packet size

### DIFF
--- a/lib/Struct.js
+++ b/lib/Struct.js
@@ -95,7 +95,7 @@ function Struct(name, defs) {
 
 
         if (varsize && !buf) {
-          buf = Buffer.alloc(size + 255); // TODO:fix my size
+          buf = Buffer.alloc(512); // Max packet size that can be received by the Bridge firmware
         } else if (!buf) {
           buf = Buffer.alloc(size);
         }


### PR DESCRIPTION
This repository contains some complex code.

The size of packets containing arrays or buffers is not calculated properly. However, the size of the packets is determined recursively within the same loop as the serialization process. By allocating the maximum packet size we only throw when the packet exceeds the maximum size.

I'm not sure what this does on homey pro though.