### PR TITLE
Fix bitmap buffer conversion

### DIFF
--- a/lib/DataTypes.js
+++ b/lib/DataTypes.js
@@ -112,7 +112,7 @@ class Bitmap {
     if (!(v instanceof Bitmap)) {
       v = new Bitmap(buf, args, v);
     }
-    return v.toBuffer(buf, i);
+    return v.toBuffer(buf, 0);
   }
 
   toArray() {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "node ./test/Struct.js",
+    "test": "node ./test/index.js",
     "lint": "eslint ."
   },
   "repository": {

--- a/test/DataTypes.js
+++ b/test/DataTypes.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const assert = require('assert');
+const { DataTypes } = require('../');
+
+const bits = ['bit1', 'bit2', 'bit3', 'bit4'];
+const bitValue = 0b0101;
+const testMap = DataTypes.map8(...bits)
+  .fromBuffer(Buffer.of(bitValue));
+
+const bufferSize = 8;
+const bufferOffset = 4;
+const expectedBuffer = Buffer.of(0, 0, 0, 0, bitValue, 0, 0, 0);
+
+// Test non-static toBuffer
+let buffer = Buffer.alloc(bufferSize);
+testMap.toBuffer(buffer, bufferOffset);
+assert.deepEqual(buffer, expectedBuffer, 'Non-static toBuffer failed');
+
+// Test static toBuffer
+buffer = Buffer.alloc(bufferSize);
+testMap.constructor.toBuffer(buffer, bufferOffset, testMap.length, bits, testMap);
+assert.deepEqual(buffer, expectedBuffer, 'Static toBuffer failed');

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,4 @@
+'use strict';
+
+require('./DataTypes');
+require('./Struct');


### PR DESCRIPTION
Due to the slice used in the method above the changed call, the target offset in the buffer must actually be zero as it otherwise writes outside the buffer space (which fails silently)