### PR TITLE
Add missing safeguards for our of range buffer reads

### DIFF
--- a/lib/DataTypes.js
+++ b/lib/DataTypes.js
@@ -166,7 +166,7 @@ function uintToBufBE(buf, v, i) {
 }
 
 function uintFromBufBE(buf, i) {
-  if (buf.length - 1 < this.length) return 0;
+  if (buf.length - i < this.length) return 0;
   return buf.readUIntBE(i, this.length);
 }
 

--- a/lib/DataTypes.js
+++ b/lib/DataTypes.js
@@ -166,6 +166,7 @@ function uintToBufBE(buf, v, i) {
 }
 
 function uintFromBufBE(buf, i) {
+  if (buf.length - 1 < this.length) return 0;
   return buf.readUIntBE(i, this.length);
 }
 
@@ -183,6 +184,7 @@ function floatToBuf(buf, v, i) {
 }
 
 function floatFromBuf(buf, i) {
+  if (buf.length - i < 4) return 0;
   return buf.readFloatLE(i);
 }
 
@@ -191,6 +193,7 @@ function doubleToBuf(buf, v, i) {
 }
 
 function doubleFromBuf(buf, i) {
+  if (buf.length - i < 8) return 0;
   return buf.readDoubleLE(i);
 }
 


### PR DESCRIPTION
Without this change the `addCluster` call would crash when using a `single` data type in a custom cluster as the initial buffer that is being read in the zigbee-clusters library is not large enough. Safeguards on the other buffer methods prevent this for happening for the `uint` types: removing the safeguard from the `uintFromBuf` would crash the app before it has the chance to start.