### PR TITLE
Rewrite type declarations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,3 +49,25 @@ jobs:
       # Finally run `npm test` (make sure you have defined a proper test command in package.json).
       - run: npm ci
       - run: npm test
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+
+    # This job validates the .d.ts declarations against test/types-test.ts which contains
+    # both positive assertions and @ts-expect-error directives. The job fails when:
+    #   - A @ts-expect-error becomes unused (types got too loose)
+    #   - A positive type assertion breaks (types got too strict or wrong)
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 20
+      - uses: webfactory/ssh-agent@v0.4.1
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+        if: env.SSH_KEY != null
+        with:
+          ssh-private-key: ${{ env.SSH_KEY }}
+      - run: npm ci
+      - run: npm run typecheck

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,21 +1,21 @@
 declare module "@athombv/data-types" {
-  class DataType<Value> {
+  class DataType<ToBuffer, FromBuffer = ToBuffer> {
     constructor(
       id: number,
       shortName: string,
       length: number,
-      toBuffer: (buffer: Buffer, value: Value, index?: number) => number,
-      fromBuffer: (buffer: Buffer, index?: number) => Value,
+      toBuffer: (buffer: Buffer, value: ToBuffer, index?: number) => number,
+      fromBuffer: (buffer: Buffer, index?: number) => FromBuffer,
       ...args: Array<unknown>
     );
 
     id: number;
     shortName: string;
     length: number;
-    toBuffer: (buffer: Buffer, value: Value, index?: number) => number;
-    fromBuffer: (buffer: Buffer, index?: number) => Value;
+    toBuffer: (buffer: Buffer, value: ToBuffer, index?: number) => number;
+    fromBuffer: (buffer: Buffer, index?: number) => FromBuffer;
     args: Array<unknown>;
-    defaultValue: Value;
+    defaultValue: FromBuffer;
 
     get isAnalog(): boolean;
     inspect(): string;
@@ -63,9 +63,9 @@ declare module "@athombv/data-types" {
     // int56: DataType<number>,
     // int64: DataType<number>,
 
-    enum8: <Flags extends string | number>(flags: Record<Flags, number>) => DataType<Flags>;
-    enum16: <Flags extends string | number>(flags: Record<Flags, number>) => DataType<Flags>;
-    enum32: <Flags extends string | number>(flags: Record<Flags, number>) => DataType<Flags>;
+    enum8: <Flags extends string | number | undefined>(flags: Record<Flags, number>) => DataType<Exclude<Flags, undefined>, Flags>;
+    enum16: <Flags extends string | number | undefined>(flags: Record<Flags, number>) => DataType<Exclude<Flags, undefined>, Flags>;
+    enum32: <Flags extends string | number | undefined>(flags: Record<Flags, number>) => DataType<Exclude<Flags, undefined>, Flags>;
 
     // semi: DataType<number>,
     single: DataType<number>;
@@ -96,7 +96,7 @@ declare module "@athombv/data-types" {
     //* Internal Types *//
     map4: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>;
     uint4: DataType<number>;
-    enum4: <Flags extends string | number>(flags: Record<Flags, number>) => DataType<Flags>;
+    enum4: <Flags extends string | number | undefined>(flags: Record<Flags, number>) => DataType<Exclude<Flags, undefined>, Flags>;
 
     buffer: DataType<Buffer>;
     buffer8: DataType<Buffer>;
@@ -180,8 +180,8 @@ declare module "@athombv/data-types" {
   }
 
   type StructProperties<Defs extends Record<string, StructField>> = {
-    [Property in keyof Defs]: Defs[Property] extends DataType<infer Type>
-      ? Type
+    [Property in keyof Defs]: Defs[Property] extends DataType<infer ToBuffer, infer FromBuffer>
+      ? FromBuffer
       : Defs[Property] extends StaticStruct<infer InnerDefs extends Record<string, StructField>>
         ? StructProperties<InnerDefs>
         : never;

--- a/index.d.ts
+++ b/index.d.ts
@@ -103,12 +103,14 @@ declare module "@athombv/data-types" {
 
     Array0: {
       <T>(type: DataType<T>): DataType<Array<T>>;
+      // Overload to allow structs in arrays
       <Defs extends Record<string, StructField>>(
         type: StaticStruct<Defs>,
       ): DataType<Array<StructProperties<Defs>>>;
     };
     Array8: {
       <T>(type: DataType<T>): DataType<Array<T>>;
+      // Overload to allow structs in arrays
       <Defs extends Record<string, StructField>>(
         type: StaticStruct<Defs>,
       ): DataType<Array<StructProperties<Defs>>>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
 declare module "@athombv/data-types" {
-  class DataType<ToBuffer, FromBuffer = ToBuffer> {
+  class DataType<ToBuffer, FromBuffer = ToBuffer, ToBufferReturn = number> {
     constructor(
       id: number,
       shortName: string,
       length: number,
-      toBuffer: (buffer: Buffer, value: ToBuffer, index?: number) => number,
+      toBuffer: (buffer: Buffer, value: ToBuffer, index?: number) => ToBufferReturn,
       fromBuffer: (buffer: Buffer, index?: number) => FromBuffer,
       ...args: Array<unknown>
     );
@@ -12,7 +12,7 @@ declare module "@athombv/data-types" {
     id: number;
     shortName: string;
     length: number;
-    toBuffer: (buffer: Buffer, value: ToBuffer, index?: number) => number;
+    toBuffer: (buffer: Buffer, value: ToBuffer, index?: number) => ToBufferReturn;
     fromBuffer: (buffer: Buffer, index?: number) => FromBuffer;
     args: Array<unknown>;
     defaultValue: FromBuffer;
@@ -22,8 +22,7 @@ declare module "@athombv/data-types" {
   }
 
   const DataTypes: {
-    // noData.toBuffer returns null instead of a number, but then noData would no longer implement the DataType interface
-    noData: DataType<any, { result:null, length: 0 }>
+    noData: DataType<any, { result:null, length: 0 }, null>
 
     data8: DataType<number>;
     data16: DataType<number>;
@@ -159,7 +158,7 @@ declare module "@athombv/data-types" {
     inspect(): string;
   }
 
-  type StructField = DataType<any> | StaticStruct<any>;
+  type StructField = DataType<any, any, any> | StaticStruct<any>;
 
   interface StaticStruct<Defs extends Record<string, StructField>> {
     get fields(): Defs;
@@ -180,7 +179,7 @@ declare module "@athombv/data-types" {
   }
 
   type StructProperties<Defs extends Record<string, StructField>> = {
-    [Property in keyof Defs]: Defs[Property] extends DataType<infer ToBuffer, infer FromBuffer>
+    [Property in keyof Defs]: Defs[Property] extends DataType<infer ToBuffer, infer FromBuffer, any>
       ? FromBuffer
       : Defs[Property] extends StaticStruct<infer InnerDefs extends Record<string, StructField>>
         ? StructProperties<InnerDefs>

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,8 @@ declare module "@athombv/data-types" {
   }
 
   const DataTypes: {
-    noData: DataType<null>;
+    // noData.toBuffer returns null instead of a number, but then noData would no longer implement the DataType interface
+    noData: DataType<{ result:null, length: 0 }>
 
     data8: DataType<number>;
     data16: DataType<number>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -146,7 +146,9 @@ declare module "@athombv/data-types" {
     inspect(): string;
   }
 
-  interface StaticStruct<Defs extends Record<string, DataType<any>>> {
+  type StructField = DataType<any> | StaticStruct<any>;
+
+  interface StaticStruct<Defs extends Record<string, StructField>> {
     get fields(): Defs;
     get name(): string;
     get length(): number;
@@ -161,19 +163,23 @@ declare module "@athombv/data-types" {
       result: StructInstance<Defs>;
       length: number;
     };
-    toBuffer(buffer?: Buffer, value?: StructInstance<Defs>, index?: number): number;
+    toBuffer(buffer?: Buffer, value?: StructProperties<Defs>, index?: number): number;
   }
 
-  type StructProperties<Defs extends Record<string, DataType<any>>> = {
-    [Property in keyof Defs]: Defs[Property] extends DataType<infer Type> ? Type : never;
+  type StructProperties<Defs extends Record<string, StructField>> = {
+    [Property in keyof Defs]: Defs[Property] extends DataType<infer Type>
+      ? Type
+      : Defs[Property] extends StaticStruct<infer InnerDefs extends Record<string, StructField>>
+        ? StructProperties<InnerDefs>
+        : never;
   };
 
-  type StructInstance<Defs extends Record<string, DataType<any>>> = StructProperties<Defs> & {
+  type StructInstance<Defs extends Record<string, StructField>> = StructProperties<Defs> & {
     toJSON: () => StructProperties<Defs>;
     toBuffer: (buffer?: Buffer, index?: number) => Buffer;
   };
 
-  function Struct<Defs extends Record<string, DataType<any>>>(
+  function Struct<Defs extends Record<string, StructField>>(
     name: string,
     defs: Defs,
     opts?: { encodeMissingFieldsBehavior?: "default" | "skip" },
@@ -202,7 +208,5 @@ const ZdoEndDeviceAnnounceBuffer = Buffer.alloc(8);
 // @ts-expect-error typo in IEEEAddr name
 ZdoEndDeviceAnnounceIndicationStruct.toBuffer(ZdoEndDeviceAnnounceBuffer, { srcAddr: 1, IEEAddr: 'abc' });
 
-Known limitations:
-- Structs in Structs are considered a no-go by these definitions.
-- Struct.fromArgs cannot be typed.
+Known limitation: Struct.fromArgs cannot be typed.
 */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,14 @@
 declare module "@athombv/data-types" {
   class DataType<Value> {
+    constructor(
+      id: number,
+      shortName: string,
+      length: number,
+      toBuffer: (buffer: Buffer, value: Value, index?: number) => number,
+      fromBuffer: (buffer: Buffer, index?: number) => Value,
+      ...args: Array<unknown>,
+    )
+
     id: number;
     shortName: string;
     length: number;
@@ -15,24 +24,25 @@ declare module "@athombv/data-types" {
   const DataTypes: {
     noData: DataType<null>,
 
-    data8 : DataType<number>,
-    data16: DataType<number>,
-    data24: DataType<number>,
-    data32: DataType<number>,
-    data40: DataType<number>,
-    data48: DataType<number>,
-    data56: DataType<number>,
+    data8 : DataType<Buffer>,
+    data16: DataType<Buffer>,
+    data24: DataType<Buffer>,
+    data32: DataType<Buffer>,
+    data40: DataType<Buffer>,
+    data48: DataType<Buffer>,
+    data56: DataType<Buffer>,
+    data64: DataType<Buffer>
 
-    bool: DataType<boolean>,
+    bool: DataType<boolean | null>,
 
-    map8 : <Flags extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
-    map16: <Flags extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
-    map24: <Flags extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
-    map32: <Flags extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
-    map40: <Flags extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
-    map48: <Flags extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
-    map56: <Flags extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
-    map64: <Flags extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
+    map8 : <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
+    map16: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
+    map24: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
+    map32: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
+    map40: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
+    map48: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
+    map56: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
+    map64: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
 
     uint8 : DataType<number>,
     uint16: DataType<number>,
@@ -60,7 +70,7 @@ declare module "@athombv/data-types" {
     single: DataType<number>,
     double: DataType<number>,
 
-    octstr: DataType<string>,
+    octstr: DataType<Buffer>,
     string: DataType<string>,
     // octstr16: DataType<string>,
     // string16: DataType<string>,
@@ -83,7 +93,7 @@ declare module "@athombv/data-types" {
     key128: DataType<string>,
 
     //* Internal Types *//
-    map4 : <Flags  extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
+    map4 : <Flags  extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
     uint4: DataType<number>,
     enum4: <Flags extends string>(flags: Record<Flags, number>) => DataType<Flags>,
 
@@ -91,12 +101,12 @@ declare module "@athombv/data-types" {
     buffer8 : DataType<Buffer>,
     buffer16: DataType<Buffer>,
 
-    Array0: <Type>(type: Type) => DataType<Array<Type>>,
-    Array8: <Type>(type: Type) => DataType<Array<Type>>,
+    Array0: <Type>(type: DataType<Type>) => DataType<Array<Type>>,
+    Array8: <Type>(type: DataType<Type>) => DataType<Array<Type>>,
     FixedString: (length: number) => DataType<string>,
   };
 
-  class BitMap<Flags extends string | null> {
+  class Bitmap<Flags extends string | null> {
     _buffer: Buffer;
     _fields: Array<Flags>;
     setBit(index: number, value: boolean): void;
@@ -105,12 +115,12 @@ declare module "@athombv/data-types" {
     setBits(bits: number | Array<Flags>): void;
     getBits(): Array<Flags>;
     get length(): number;
-    static fromBuffer<Flags extends string | null>(buffer: Buffer, index: number, length: number, flags: Array<Flags>): BitMap<Flags>;
+    static fromBuffer<Flags extends string | null>(buffer: Buffer, index: number, length: number, flags: Array<Flags>): Bitmap<Flags>;
     static toBuffer<Flags extends string | null>(buffer: Buffer, index: number, length: number, flags: Array<Flags>, value: number): number;
-    static toBuffer<Flags extends string | null>(buffer: Buffer, index: number, length: number, flags: Array<Flags> | undefined, value: BitMap<Flags>): number;
+    static toBuffer<Flags extends string | null>(buffer: Buffer, index: number, length: number, flags: Array<Flags> | undefined, value: Bitmap<Flags>): number;
     toArray(): Array<Flags>;
     toBuffer(buffer: Buffer, index: number): Buffer;
-    copy(): BitMap<Flags>;
+    copy(): Bitmap<Flags>;
     toJSON(): object;
     inspect(): string;
   }
@@ -126,12 +136,12 @@ declare module "@athombv/data-types" {
       result: StructInstance<Defs>,
       length: number,
     }
-    toBuffer(buffer: Buffer, value: StructInstance<Defs>, index?: number): number;
+    toBuffer(buffer?: Buffer, value?: StructInstance<Defs>, index?: number): number;
   }
 
   type StructInstance<Defs extends Record<string, import('@athombv/data-types').DataType<any>>> = StructProperties<Defs> & {
     toJSON: () => StructProperties<Defs>;
-    toBuffer: (buffer: Buffer, index?: number) => Buffer;
+    toBuffer: (buffer?: Buffer, index?: number) => Buffer;
   }
 
   function Struct<Defs extends Record<string, DataType<any>>> (name: string, defs: Defs, opts?: {encodeMissingFieldsBehavior?: 'default' | 'skip'}): StaticStruct<Defs>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,8 +6,8 @@ declare module "@athombv/data-types" {
       length: number,
       toBuffer: (buffer: Buffer, value: Value, index?: number) => number,
       fromBuffer: (buffer: Buffer, index?: number) => Value,
-      ...args: Array<unknown>,
-    )
+      ...args: Array<unknown>
+    );
 
     id: number;
     shortName: string;
@@ -22,56 +22,56 @@ declare module "@athombv/data-types" {
   }
 
   const DataTypes: {
-    noData: DataType<null>,
+    noData: DataType<null>;
 
-    data8 : DataType<Buffer>,
-    data16: DataType<Buffer>,
-    data24: DataType<Buffer>,
-    data32: DataType<Buffer>,
-    data40: DataType<Buffer>,
-    data48: DataType<Buffer>,
-    data56: DataType<Buffer>,
-    data64: DataType<Buffer>
+    data8: DataType<Buffer>;
+    data16: DataType<Buffer>;
+    data24: DataType<Buffer>;
+    data32: DataType<Buffer>;
+    data40: DataType<Buffer>;
+    data48: DataType<Buffer>;
+    data56: DataType<Buffer>;
+    data64: DataType<Buffer>;
 
-    bool: DataType<boolean | null>,
+    bool: DataType<boolean | null>;
 
-    map8 : <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
-    map16: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
-    map24: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
-    map32: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
-    map40: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
-    map48: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
-    map56: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
-    map64: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
+    map8: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>;
+    map16: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>;
+    map24: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>;
+    map32: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>;
+    map40: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>;
+    map48: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>;
+    map56: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>;
+    map64: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>;
 
-    uint8 : DataType<number>,
-    uint16: DataType<number>,
-    uint24: DataType<number>,
-    uint32: DataType<number>,
-    uint40: DataType<number>,
-    uint48: DataType<number>,
+    uint8: DataType<number>;
+    uint16: DataType<number>;
+    uint24: DataType<number>;
+    uint32: DataType<number>;
+    uint40: DataType<number>;
+    uint48: DataType<number>;
     // uint56: DataType<number>,
     // uint64: DataType<number>,
 
-    int8 : DataType<number>,
-    int16: DataType<number>,
-    int24: DataType<number>,
-    int32: DataType<number>,
-    int40: DataType<number>,
-    int48: DataType<number>,
+    int8: DataType<number>;
+    int16: DataType<number>;
+    int24: DataType<number>;
+    int32: DataType<number>;
+    int40: DataType<number>;
+    int48: DataType<number>;
     // int56: DataType<number>,
     // int64: DataType<number>,
 
-    enum8 : <Flags extends string | number>(flags: Record<Flags, number>) => DataType<Flags>,
-    enum16: <Flags extends string | number>(flags: Record<Flags, number>) => DataType<Flags>,
-    enum32: <Flags extends string | number>(flags: Record<Flags, number>) => DataType<Flags>,
+    enum8: <Flags extends string | number>(flags: Record<Flags, number>) => DataType<Flags>;
+    enum16: <Flags extends string | number>(flags: Record<Flags, number>) => DataType<Flags>;
+    enum32: <Flags extends string | number>(flags: Record<Flags, number>) => DataType<Flags>;
 
     // semi: DataType<number>,
-    single: DataType<number>,
-    double: DataType<number>,
+    single: DataType<number>;
+    double: DataType<number>;
 
-    octstr: DataType<Buffer>,
-    string: DataType<string>,
+    octstr: DataType<Buffer>;
+    string: DataType<string>;
     // octstr16: DataType<string>,
     // string16: DataType<string>,
 
@@ -88,22 +88,22 @@ declare module "@athombv/data-types" {
     // attribId
 
     // bacOID
-    EUI48 : DataType<string>,
-    EUI64 : DataType<string>,
-    key128: DataType<string>,
+    EUI48: DataType<string>;
+    EUI64: DataType<string>;
+    key128: DataType<string>;
 
     //* Internal Types *//
-    map4 : <Flags  extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
-    uint4: DataType<number>,
-    enum4: <Flags extends string | number>(flags: Record<Flags, number>) => DataType<Flags>,
+    map4: <Flags extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>;
+    uint4: DataType<number>;
+    enum4: <Flags extends string | number>(flags: Record<Flags, number>) => DataType<Flags>;
 
-    buffer  : DataType<Buffer>,
-    buffer8 : DataType<Buffer>,
-    buffer16: DataType<Buffer>,
+    buffer: DataType<Buffer>;
+    buffer8: DataType<Buffer>;
+    buffer16: DataType<Buffer>;
 
-    Array0: <Type>(type: DataType<Type>) => DataType<Array<Type>>,
-    Array8: <Type>(type: DataType<Type>) => DataType<Array<Type>>,
-    FixedString: (length: number) => DataType<string>,
+    Array0: <Type>(type: DataType<Type>) => DataType<Array<Type>>;
+    Array8: <Type>(type: DataType<Type>) => DataType<Array<Type>>;
+    FixedString: (length: number) => DataType<string>;
   };
 
   class Bitmap<Flags extends string | null> {
@@ -115,9 +115,26 @@ declare module "@athombv/data-types" {
     setBits(bits: number | Array<Flags>): void;
     getBits(): Array<Flags>;
     get length(): number;
-    static fromBuffer<Flags extends string | null>(buffer: Buffer, index: number, length: number, flags: Array<Flags>): Bitmap<Flags>;
-    static toBuffer<Flags extends string | null>(buffer: Buffer, index: number, length: number, flags: Array<Flags>, value: number): number;
-    static toBuffer<Flags extends string | null>(buffer: Buffer, index: number, length: number, flags: Array<Flags> | undefined, value: Bitmap<Flags>): number;
+    static fromBuffer<Flags extends string | null>(
+      buffer: Buffer,
+      index: number,
+      length: number,
+      flags: Array<Flags>,
+    ): Bitmap<Flags>;
+    static toBuffer<Flags extends string | null>(
+      buffer: Buffer,
+      index: number,
+      length: number,
+      flags: Array<Flags>,
+      value: number,
+    ): number;
+    static toBuffer<Flags extends string | null>(
+      buffer: Buffer,
+      index: number,
+      length: number,
+      flags: Array<Flags> | undefined,
+      value: Bitmap<Flags>,
+    ): number;
     toArray(): Array<Flags>;
     toBuffer(buffer: Buffer, index: number): Buffer;
     copy(): Bitmap<Flags>;
@@ -132,25 +149,36 @@ declare module "@athombv/data-types" {
     fromJSON(props: any): StructInstance<Defs>;
     fromArgs(...args: Array<unknown>): StructInstance<Defs>;
     fromBuffer(buffer: Buffer, index?: number, returnLength?: false): StructInstance<Defs>;
-    fromBuffer(buffer: Buffer, index?: number, returnLength?: true): {
-      result: StructInstance<Defs>,
-      length: number,
-    }
+    fromBuffer(
+      buffer: Buffer,
+      index?: number,
+      returnLength?: true,
+    ): {
+      result: StructInstance<Defs>;
+      length: number;
+    };
     toBuffer(buffer?: Buffer, value?: StructInstance<Defs>, index?: number): number;
   }
 
   type StructInstance<Defs extends Record<string, DataType<any>>> = StructProperties<Defs> & {
     toJSON: () => StructProperties<Defs>;
     toBuffer: (buffer?: Buffer, index?: number) => Buffer;
-  }
+  };
 
-  function Struct<Defs extends Record<string, DataType<any>>> (name: string, defs: Defs, opts?: {encodeMissingFieldsBehavior?: 'default' | 'skip'}): StaticStruct<Defs>;
+  function Struct<Defs extends Record<string, DataType<any>>>(
+    name: string,
+    defs: Defs,
+    opts?: { encodeMissingFieldsBehavior?: "default" | "skip" },
+  ): StaticStruct<Defs>;
 }
 
-type StructProperties<Defs extends Record<string, import('@athombv/data-types').DataType<any>>> = {
-  [Property in keyof Defs]: Defs[Property] extends import('@athombv/data-types').DataType<infer Type> ? Type : never
-}
-
+type StructProperties<Defs extends Record<string, import("@athombv/data-types").DataType<any>>> = {
+  [Property in keyof Defs]: Defs[Property] extends import("@athombv/data-types").DataType<
+    infer Type
+  >
+    ? Type
+    : never;
+};
 
 /*
 How to use @athombv/data-types in TypeScript:

--- a/index.d.ts
+++ b/index.d.ts
@@ -101,8 +101,18 @@ declare module "@athombv/data-types" {
     buffer8: DataType<Buffer>;
     buffer16: DataType<Buffer>;
 
-    Array0: <Type>(type: DataType<Type>) => DataType<Array<Type>>;
-    Array8: <Type>(type: DataType<Type>) => DataType<Array<Type>>;
+    Array0: {
+      <T>(type: DataType<T>): DataType<Array<T>>;
+      <Defs extends Record<string, StructField>>(
+        type: StaticStruct<Defs>,
+      ): DataType<Array<StructProperties<Defs>>>;
+    };
+    Array8: {
+      <T>(type: DataType<T>): DataType<Array<T>>;
+      <Defs extends Record<string, StructField>>(
+        type: StaticStruct<Defs>,
+      ): DataType<Array<StructProperties<Defs>>>;
+    };
     FixedString: (length: number) => DataType<string>;
   };
 
@@ -207,6 +217,9 @@ ZdoEndDeviceAnnounceObject.srcAddr.trim();
 const ZdoEndDeviceAnnounceBuffer = Buffer.alloc(8);
 // @ts-expect-error typo in IEEEAddr name
 ZdoEndDeviceAnnounceIndicationStruct.toBuffer(ZdoEndDeviceAnnounceBuffer, { srcAddr: 1, IEEAddr: 'abc' });
+
+const Item = Struct('Item', { a: DataTypes.uint8, b: DataTypes.uint8 });
+const ArrayOfItems = DataTypes.Array8(Item);
 
 Known limitation: Struct.fromArgs cannot be typed.
 */

--- a/index.d.ts
+++ b/index.d.ts
@@ -62,9 +62,9 @@ declare module "@athombv/data-types" {
     // int56: DataType<number>,
     // int64: DataType<number>,
 
-    enum8 : <Flags extends string>(flags: Record<Flags, number>) => DataType<Flags>,
-    enum16: <Flags extends string>(flags: Record<Flags, number>) => DataType<Flags>,
-    enum32: <Flags extends string>(flags: Record<Flags, number>) => DataType<Flags>,
+    enum8 : <Flags extends string | number>(flags: Record<Flags, number>) => DataType<Flags>,
+    enum16: <Flags extends string | number>(flags: Record<Flags, number>) => DataType<Flags>,
+    enum32: <Flags extends string | number>(flags: Record<Flags, number>) => DataType<Flags>,
 
     // semi: DataType<number>,
     single: DataType<number>,
@@ -95,7 +95,7 @@ declare module "@athombv/data-types" {
     //* Internal Types *//
     map4 : <Flags  extends string | null>(...flags: Array<Flags>) => DataType<Bitmap<Flags>>,
     uint4: DataType<number>,
-    enum4: <Flags extends string>(flags: Record<Flags, number>) => DataType<Flags>,
+    enum4: <Flags extends string | number>(flags: Record<Flags, number>) => DataType<Flags>,
 
     buffer  : DataType<Buffer>,
     buffer8 : DataType<Buffer>,

--- a/index.d.ts
+++ b/index.d.ts
@@ -139,7 +139,7 @@ declare module "@athombv/data-types" {
     toBuffer(buffer?: Buffer, value?: StructInstance<Defs>, index?: number): number;
   }
 
-  type StructInstance<Defs extends Record<string, import('@athombv/data-types').DataType<any>>> = StructProperties<Defs> & {
+  type StructInstance<Defs extends Record<string, DataType<any>>> = StructProperties<Defs> & {
     toJSON: () => StructProperties<Defs>;
     toBuffer: (buffer?: Buffer, index?: number) => Buffer;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -164,6 +164,10 @@ declare module "@athombv/data-types" {
     toBuffer(buffer?: Buffer, value?: StructInstance<Defs>, index?: number): number;
   }
 
+  type StructProperties<Defs extends Record<string, DataType<any>>> = {
+    [Property in keyof Defs]: Defs[Property] extends DataType<infer Type> ? Type : never;
+  };
+
   type StructInstance<Defs extends Record<string, DataType<any>>> = StructProperties<Defs> & {
     toJSON: () => StructProperties<Defs>;
     toBuffer: (buffer?: Buffer, index?: number) => Buffer;
@@ -175,14 +179,6 @@ declare module "@athombv/data-types" {
     opts?: { encodeMissingFieldsBehavior?: "default" | "skip" },
   ): StaticStruct<Defs>;
 }
-
-type StructProperties<Defs extends Record<string, import("@athombv/data-types").DataType<any>>> = {
-  [Property in keyof Defs]: Defs[Property] extends import("@athombv/data-types").DataType<
-    infer Type
-  >
-    ? Type
-    : never;
-};
 
 /*
 How to use @athombv/data-types in TypeScript:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,131 +1,158 @@
-type ToBuffer = (buffer: Buffer, value: unknown, index: number) => Buffer;
-type FromBuffer = (buffer: Buffer, index: number, returnLength: boolean) => unknown;
-
-declare module "@athombv/data-types" {  
-  interface DataTypeInterface {
+declare module "@athombv/data-types" {
+  class DataType<Value> {
     id: number;
     shortName: string;
     length: number;
-    toBuffer: ToBuffer;
-    fromBuffer: FromBuffer;
-    args: unknown[];
-    defaultValue: unknown;
-  
-    isAnalog: () => boolean;
-    inspect: () => string;
+    toBuffer: (buffer: Buffer, value: Value, index?: number) => number;
+    fromBuffer: (buffer: Buffer, index?: number) => Value;
+    args: Array<unknown>;
+    defaultValue: Value;
+
+    get isAnalog(): boolean;
+    inspect(): string;
   }
-  
-  interface DataTypeConstructor {
-    new (
-      id: number,
-      shortName: string,
+
+  const DataTypes: {
+    noData: DataType<null>,
+
+    data8 : DataType<number>,
+    data16: DataType<number>,
+    data24: DataType<number>,
+    data32: DataType<number>,
+    data40: DataType<number>,
+    data48: DataType<number>,
+    data56: DataType<number>,
+
+    bool: DataType<boolean>,
+
+    map8 : <Flags extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
+    map16: <Flags extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
+    map24: <Flags extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
+    map32: <Flags extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
+    map40: <Flags extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
+    map48: <Flags extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
+    map56: <Flags extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
+    map64: <Flags extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
+
+    uint8 : DataType<number>,
+    uint16: DataType<number>,
+    uint24: DataType<number>,
+    uint32: DataType<number>,
+    uint40: DataType<number>,
+    uint48: DataType<number>,
+    // uint56: DataType<number>,
+    // uint64: DataType<number>,
+
+    int8 : DataType<number>,
+    int16: DataType<number>,
+    int24: DataType<number>,
+    int32: DataType<number>,
+    int40: DataType<number>,
+    int48: DataType<number>,
+    // int56: DataType<number>,
+    // int64: DataType<number>,
+
+    enum8 : <Flags extends string>(flags: Record<Flags, number>) => DataType<Flags>,
+    enum16: <Flags extends string>(flags: Record<Flags, number>) => DataType<Flags>,
+    enum32: <Flags extends string>(flags: Record<Flags, number>) => DataType<Flags>,
+
+    // semi: DataType<number>,
+    single: DataType<number>,
+    double: DataType<number>,
+
+    octstr: DataType<string>,
+    string: DataType<string>,
+    // octstr16: DataType<string>,
+    // string16: DataType<string>,
+
+    // array
+    // struct
+    // set
+    // bag
+
+    // ToD
+    // date
+    // UTC
+
+    // clusterId
+    // attribId
+
+    // bacOID
+    EUI48 : DataType<string>,
+    EUI64 : DataType<string>,
+    key128: DataType<string>,
+
+    //* Internal Types *//
+    map4 : <Flags  extends string | null>(flags: Array<Flags>) => DataType<BitMap<Flags>>,
+    uint4: DataType<number>,
+    enum4: <Flags extends string>(flags: Record<Flags, number>) => DataType<Flags>,
+
+    buffer  : DataType<Buffer>,
+    buffer8 : DataType<Buffer>,
+    buffer16: DataType<Buffer>,
+
+    Array0: <Type>(type: Type) => DataType<Array<Type>>,
+    Array8: <Type>(type: Type) => DataType<Array<Type>>,
+    FixedString: (length: number) => DataType<string>,
+  };
+
+  class BitMap<Flags extends string | null> {
+    _buffer: Buffer;
+    _fields: Array<Flags>;
+    setBit(index: number, value: boolean): void;
+    getBit(index: number): boolean;
+    clearBit(index: number): void;
+    setBits(bits: number | Array<Flags>): void;
+    getBits(): Array<Flags>;
+    get length(): number;
+    static fromBuffer<Flags extends string | null>(buffer: Buffer, index: number, length: number, flags: Array<Flags>): BitMap<Flags>;
+    static toBuffer<Flags extends string | null>(buffer: Buffer, index: number, length: number, flags: Array<Flags>, value: number): number;
+    static toBuffer<Flags extends string | null>(buffer: Buffer, index: number, length: number, flags: Array<Flags> | undefined, value: BitMap<Flags>): number;
+    toArray(): Array<Flags>;
+    toBuffer(buffer: Buffer, index: number): Buffer;
+    copy(): BitMap<Flags>;
+    toJSON(): object;
+    inspect(): string;
+  }
+
+  interface StaticStruct<Defs extends Record<string, DataType<any>>> {
+    get fields(): Defs;
+    get name(): string;
+    get length(): number;
+    fromJSON(props: any): StructInstance<Defs>;
+    fromArgs(...args: Array<unknown>): StructInstance<Defs>;
+    fromBuffer(buffer: Buffer, index?: number, returnLength?: false): StructInstance<Defs>;
+    fromBuffer(buffer: Buffer, index?: number, returnLength?: true): {
+      result: StructInstance<Defs>,
       length: number,
-      toBuf: ToBuffer,
-      fromBuf: FromBuffer,
-      ...args: unknown[]
-    ): DataTypeInterface;
+    }
+    toBuffer(buffer: Buffer, value: StructInstance<Defs>, index?: number): number;
   }
-  
-  interface DataTypeFunctionConstructor {
-    (...args: unknown[]): DataTypeConstructor;
+
+  type StructInstance<Defs extends Record<string, import('@athombv/data-types').DataType<any>>> = StructProperties<Defs> & {
+    toJSON: () => StructProperties<Defs>;
+    toBuffer: (buffer: Buffer, index?: number) => Buffer;
   }
-  
-  type DataTypeItem =
-    | DataTypeConstructor
-    | DataTypeFunctionConstructor
-    | { [name: string]: DataTypeItem }; // This OR is needed for Structs with a second level of DataTypes
-  
-  type GenericMap<T> = {
-    [K in keyof T]: DataTypeItem;
-  };
-  
-  interface StructTypeInterface<T> {
-    toJSON: () => T;
-    toBuffer: (buffer?: Buffer, index?: number) => Buffer;
-  }
-  
-  export interface StructInstance<StructType> {
-    fromBuffer: (buffer: Buffer) => StructType & StructTypeInterface<StructType>;
-    toBuffer: (buffer: Buffer, object: StructType, index?: number) => Buffer;
-    fields: GenericMap<StructType>;
-    name: string;
-    length: number;
-    fromJSON: (object: StructType) => StructType & StructTypeInterface<StructType>;
-    fromArgs: (...args: unknown[]) => StructType & StructTypeInterface<StructType>;
-  }
-  export const DataTypes: {
-    noData: DataTypeConstructor;
-    data8: DataTypeConstructor;
-    data16: DataTypeConstructor;
-    data24: DataTypeConstructor;
-    data32: DataTypeConstructor;
-    data40: DataTypeConstructor;
-    data48: DataTypeConstructor;
-    data56: DataTypeConstructor;
-    data64: DataTypeConstructor;
-    bool: DataTypeConstructor;
-    map8: DataTypeFunctionConstructor;
-    map16: DataTypeFunctionConstructor;
-    map24: DataTypeFunctionConstructor;
-    map32: DataTypeFunctionConstructor;
-    map40: DataTypeFunctionConstructor;
-    map48: DataTypeFunctionConstructor;
-    map56: DataTypeFunctionConstructor;
-    map64: DataTypeFunctionConstructor;
-    uint8: DataTypeConstructor;
-    uint16: DataTypeConstructor;
-    uint24: DataTypeConstructor;
-    uint32: DataTypeConstructor;
-    uint40: DataTypeConstructor;
-    uint48: DataTypeConstructor;
-    int8: DataTypeConstructor;
-    int16: DataTypeConstructor;
-    int24: DataTypeConstructor;
-    int32: DataTypeConstructor;
-    int40: DataTypeConstructor;
-    int48: DataTypeConstructor;
-    enum8: DataTypeFunctionConstructor;
-    enum16: DataTypeFunctionConstructor;
-    enum32: DataTypeFunctionConstructor;
-    single: DataTypeConstructor;
-    double: DataTypeConstructor;
-    octstr: DataTypeConstructor;
-    string: DataTypeConstructor;
-    EUI48: DataTypeConstructor;
-    EUI64: DataTypeConstructor;
-    key128: DataTypeConstructor;
-    uint4: DataTypeConstructor;
-    enum4: DataTypeFunctionConstructor;
-    map4: DataTypeFunctionConstructor;
-    buffer: DataTypeConstructor;
-    buffer8: DataTypeConstructor;
-    buffer16: DataTypeConstructor;
-    Array0: DataTypeFunctionConstructor;
-    Array8: DataTypeFunctionConstructor;
-    FixedString: DataTypeFunctionConstructor;
-  };
-  export const DataType: DataTypeInterface;
-  export function Struct<StructType>(
-    name: string,
-    objectDefinition: GenericMap<StructType>
-  ): StructInstance<StructType>;
+
+  function Struct<Defs extends Record<string, DataType<any>>> (name: string, defs: Defs, opts?: {encodeMissingFieldsBehavior?: 'default' | 'skip'}): StaticStruct<Defs>;
 }
+
+type StructProperties<Defs extends Record<string, import('@athombv/data-types').DataType<any>>> = {
+  [Property in keyof Defs]: Defs[Property] extends import('@athombv/data-types').DataType<infer Type> ? Type : never
+}
+
 
 /*
 How to use @athombv/data-types in TypeScript:
 
 // Create a type that represents the Struct data
-type ZdoEndDeviceAnnounceIndication = {
-  srcAddr: number;
-  IEEEAddr: string;
+const ZdoEndDeviceAnnounceIndication = {
+  srcAddr: DataTypes.uint16,
+  IEEEAddr: DataTypes.EUI64,
 };
 
 // Create a Struct instance with generic type ZdoEndDeviceAnnounceIndication
-const ZdoEndDeviceAnnounceIndicationStruct =
-  Struct<ZdoEndDeviceAnnounceIndication>("ZdoEndDeviceAnnounceIndication", {
-    srcAddr: DataTypes.uint16,
-    IEEEAddr: DataTypes.EUI64,
-  });
+const ZdoEndDeviceAnnounceIndicationStruct = Struct("ZdoEndDeviceAnnounceIndication", ZdoEndDeviceAnnounceIndication);
 
 // Create ZdoEndDeviceAnnounceIndication object
 const ZdoEndDeviceAnnounceObject = ZdoEndDeviceAnnounceIndicationStruct.fromBuffer(
@@ -135,9 +162,10 @@ const ZdoEndDeviceAnnounceObject = ZdoEndDeviceAnnounceIndicationStruct.fromBuff
 ZdoEndDeviceAnnounceObject.srcAddr.trim(); // This errors, srcAddr is not a string
 
 // Create Buffer instance from ZdoEndDeviceAnnounceObject
-const ZdoEndDeviceAnnounceBuffer = ZdoEndDeviceAnnounceIndicationStruct.toBuffer({ srcAddr: 1, IEEAddr: 'abc' }); // This errors due to typo in IEEEAddr name
+const ZdoEndDeviceAnnounceBuffer = Buffer.alloc(8);
+ZdoEndDeviceAnnounceIndicationStruct.toBuffer(ZdoEndDeviceAnnounceBuffer, { srcAddr: 1, IEEAddr: 'abc' }); // This errors due to typo in IEEEAddr name
 
 Known limitations:
 - Structs in Structs are considered a no-go by these definitions.
-- DataTypes have no related JS type, so a few unknowns are used.
+- Struct.fromArgs cannot be typed.
 */

--- a/index.d.ts
+++ b/index.d.ts
@@ -155,25 +155,24 @@ type StructProperties<Defs extends Record<string, import('@athombv/data-types').
 /*
 How to use @athombv/data-types in TypeScript:
 
-// Create a type that represents the Struct data
-const ZdoEndDeviceAnnounceIndication = {
+// Create a Struct instance
+const ZdoEndDeviceAnnounceIndicationStruct = Struct("ZdoEndDeviceAnnounceIndication", {
   srcAddr: DataTypes.uint16,
   IEEEAddr: DataTypes.EUI64,
-};
+});
 
-// Create a Struct instance with generic type ZdoEndDeviceAnnounceIndication
-const ZdoEndDeviceAnnounceIndicationStruct = Struct("ZdoEndDeviceAnnounceIndication", ZdoEndDeviceAnnounceIndication);
-
-// Create ZdoEndDeviceAnnounceIndication object
+// Create ZdoEndDeviceAnnounceIndication object from a buffer
 const ZdoEndDeviceAnnounceObject = ZdoEndDeviceAnnounceIndicationStruct.fromBuffer(
   Buffer.from([0, 1, 2, 3])
 );
 
-ZdoEndDeviceAnnounceObject.srcAddr.trim(); // This errors, srcAddr is not a string
+// @ts-expect-error srcAddr is not a string
+ZdoEndDeviceAnnounceObject.srcAddr.trim();
 
 // Create Buffer instance from ZdoEndDeviceAnnounceObject
 const ZdoEndDeviceAnnounceBuffer = Buffer.alloc(8);
-ZdoEndDeviceAnnounceIndicationStruct.toBuffer(ZdoEndDeviceAnnounceBuffer, { srcAddr: 1, IEEAddr: 'abc' }); // This errors due to typo in IEEEAddr name
+// @ts-expect-error typo in IEEEAddr name
+ZdoEndDeviceAnnounceIndicationStruct.toBuffer(ZdoEndDeviceAnnounceBuffer, { srcAddr: 1, IEEAddr: 'abc' });
 
 Known limitations:
 - Structs in Structs are considered a no-go by these definitions.

--- a/index.d.ts
+++ b/index.d.ts
@@ -106,7 +106,11 @@ declare module "@athombv/data-types" {
     FixedString: (length: number) => DataType<string>;
   };
 
-  class Bitmap<Flags extends string | null> {
+  type Bitmap<Flags extends string | null> = BitmapBase<Flags> & {
+    [K in Flags as K extends string ? K : never]: boolean;
+  };
+
+  class BitmapBase<Flags extends string | null> {
     _buffer: Buffer;
     _fields: Array<Flags>;
     setBit(index: number, value: boolean): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -126,7 +126,7 @@ declare module "@athombv/data-types" {
   class BitmapBase<Flags extends string | null> {
     _buffer: Buffer;
     _fields: Array<Flags>;
-    setBit(index: number, value: boolean): void;
+    setBit(index: number, value?: boolean): void;
     getBit(index: number): boolean;
     clearBit(index: number): void;
     setBits(bits: number | Array<Flags>): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,10 +24,10 @@ declare module "@athombv/data-types" {
   const DataTypes: {
     noData: DataType<null>;
 
-    data8: DataType<Buffer>;
-    data16: DataType<Buffer>;
-    data24: DataType<Buffer>;
-    data32: DataType<Buffer>;
+    data8: DataType<number>;
+    data16: DataType<number>;
+    data24: DataType<number>;
+    data32: DataType<number>;
     data40: DataType<Buffer>;
     data48: DataType<Buffer>;
     data56: DataType<Buffer>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ declare module "@athombv/data-types" {
 
   const DataTypes: {
     // noData.toBuffer returns null instead of a number, but then noData would no longer implement the DataType interface
-    noData: DataType<{ result:null, length: 0 }>
+    noData: DataType<any, { result:null, length: 0 }>
 
     data8: DataType<number>;
     data16: DataType<number>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2274,6 +2274,12 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
+    "typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "test": "mocha --extension test.js test",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint ."
   },
   "engines": {
@@ -33,6 +34,7 @@
     "@types/node": "^18.11.9",
     "eslint": "^6.8.0",
     "eslint-config-athom": "^2.0.8",
-    "mocha": "^10.2.0"
+    "mocha": "^10.2.0",
+    "typescript": "^6.0.3"
   }
 }

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -134,6 +134,11 @@ if (mode.m === "UNKNOWN") {
 const Half = DataTypes.enum4({ LO: 0, HI: 1 });
 const half = Struct("Half", { h: Half, _pad: DataTypes.uint4 }).fromBuffer(emptyBuf(1));
 const _half: "LO" | "HI" = half.h;
+// @ts-expect-error value should be part of the enum
+const _halfWrong: "Wrong" = half.h;
+const _halfDefault: "LO" | "HI" = Half.defaultValue;
+// @ts-expect-error default value should be part of the enum
+const _halfDefaultWrong: "Wrong" = Half.defaultValue;
 
 // Numeric keys are supported (new in this PR). Object literal numeric keys
 // become strings at runtime, but the type allows either.

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -84,6 +84,11 @@ const _bool: boolean | null = bools.b;
 // @ts-expect-error bool can be null, plain boolean is too narrow
 const _boolWrong: boolean = bools.b;
 
+DataTypes.bool.toBuffer(emptyBuf(), true);
+DataTypes.bool.toBuffer(emptyBuf(), null);
+// @ts-expect-error bool written to buffer must be boolean or null
+DataTypes.bool.toBuffer(emptyBuf(), 1);
+
 // EUI addresses / keys return string (hex-formatted)
 const addrs = Struct("Addrs", {
   e48: DataTypes.EUI48,

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -1,0 +1,353 @@
+/**
+ * Type-level regression tests for @athombv/data-types.
+ *
+ * This file is NEVER EXECUTED. It is type-checked only, via `npm run typecheck`.
+ * It validates the public contract in index.d.ts using two techniques:
+ *
+ *   1. Positive assertions:  `const x: ExpectedType = someValue`
+ *      Fails to compile if `someValue` is not assignable to `ExpectedType`.
+ *
+ *   2. Negative assertions:  `// @ts-expect-error` above an expression
+ *      Fails to compile ("Unused '@ts-expect-error' directive") if the
+ *      expression no longer produces a type error.
+ *
+ * When a change makes a directive "unused", you must decide:
+ *   - Intentional fix  -> delete the directive.
+ *   - Accidental loosening -> revert the change.
+ *
+ * Unused local bindings are fine - this file only exists for its side effect
+ * on the type checker.
+ */
+
+import { DataType, Struct, DataTypes } from "@athombv/data-types";
+
+// ---------------------------------------------------------------------------
+// Helper - reduces boilerplate when we only care about the parsed struct type
+// ---------------------------------------------------------------------------
+
+const emptyBuf = (size = 64) => Buffer.alloc(size);
+
+// ===========================================================================
+// 1. Primitive DataType value types
+// ---------------------------------------------------------------------------
+// Regressions here silently change what consumers read from a buffer. Each
+// assertion pins the expected value type.
+// ===========================================================================
+
+// Integers - all return number
+const ints = Struct("Ints", {
+  u8: DataTypes.uint8,
+  u16: DataTypes.uint16,
+  u32: DataTypes.uint32,
+  i8: DataTypes.int8,
+  i32: DataTypes.int32,
+  u4: DataTypes.uint4,
+  sng: DataTypes.single,
+  dbl: DataTypes.double,
+}).fromBuffer(emptyBuf());
+const _intU8: number = ints.u8;
+const _intU16: number = ints.u16;
+const _intU32: number = ints.u32;
+const _intI8: number = ints.i8;
+const _intI32: number = ints.i32;
+const _intU4: number = ints.u4;
+const _intSng: number = ints.sng;
+const _intDbl: number = ints.dbl;
+
+// data8..data64 return Buffer (NOT number - corrected in this PR)
+const datas = Struct("Datas", {
+  d8: DataTypes.data8,
+  d16: DataTypes.data16,
+  d64: DataTypes.data64,
+}).fromBuffer(emptyBuf());
+const _dataD8: Buffer = datas.d8;
+const _dataD16: Buffer = datas.d16;
+const _dataD64: Buffer = datas.d64;
+// @ts-expect-error data8 is Buffer, not number
+const _dataD8Wrong: number = datas.d8;
+
+// octstr returns Buffer, string returns string (octstr was incorrectly typed as string before)
+const strs = Struct("Strs", {
+  oct: DataTypes.octstr,
+  utf: DataTypes.string,
+  fixed: DataTypes.FixedString(8),
+}).fromBuffer(emptyBuf());
+const _strOct: Buffer = strs.oct;
+const _strUtf: string = strs.utf;
+const _strFixed: string = strs.fixed;
+// @ts-expect-error octstr is Buffer, not string
+const _strOctWrong: string = strs.oct;
+
+// bool returns boolean | null (was incorrectly `boolean` before - 0xff means null at runtime)
+const bools = Struct("Bools", { b: DataTypes.bool }).fromBuffer(emptyBuf());
+const _bool: boolean | null = bools.b;
+// @ts-expect-error bool can be null, plain boolean is too narrow
+const _boolWrong: boolean = bools.b;
+
+// EUI addresses / keys return string (hex-formatted)
+const addrs = Struct("Addrs", {
+  e48: DataTypes.EUI48,
+  e64: DataTypes.EUI64,
+  k: DataTypes.key128,
+}).fromBuffer(emptyBuf());
+const _addrE48: string = addrs.e48;
+const _addrE64: string = addrs.e64;
+const _addrKey: string = addrs.k;
+
+// Length-prefixed buffers
+const bufs = Struct("Bufs", {
+  b: DataTypes.buffer,
+  b8: DataTypes.buffer8,
+  b16: DataTypes.buffer16,
+}).fromBuffer(emptyBuf());
+const _bufPlain: Buffer = bufs.b;
+const _buf8: Buffer = bufs.b8;
+const _buf16: Buffer = bufs.b16;
+
+// noData always returns null
+const none = Struct("None", { n: DataTypes.noData }).fromBuffer(emptyBuf());
+const _noData: null = none.n;
+
+// ===========================================================================
+// 2. Enum narrowing
+// ---------------------------------------------------------------------------
+// Enum value types narrow to the literal union of the provided keys, so
+// `if (value === "UNKNOWN")` is caught as a typo.
+// ===========================================================================
+
+const Mode = DataTypes.enum8({ OFF: 0, ON: 1, AUTO: 2 });
+const mode = Struct("Mode", { m: Mode }).fromBuffer(emptyBuf(1));
+const _mode: "OFF" | "ON" | "AUTO" = mode.m;
+
+// Comparing to a declared enum value is fine.
+if (mode.m === "ON") {
+  /* reachable */
+}
+// @ts-expect-error "UNKNOWN" is not one of the declared keys
+if (mode.m === "UNKNOWN") {
+  /* unreachable */
+}
+
+// enum4 narrows the same way (4-bit variant).
+const Half = DataTypes.enum4({ LO: 0, HI: 1 });
+const half = Struct("Half", { h: Half, _pad: DataTypes.uint4 }).fromBuffer(emptyBuf(1));
+const _half: "LO" | "HI" = half.h;
+
+// Numeric keys are supported (new in this PR). Object literal numeric keys
+// become strings at runtime, but the type allows either.
+const Status = DataTypes.enum8({ 0x00: 0, 0x01: 1, 0x80: 2 });
+const statusEnum = Struct("StatusEnum", { s: Status }).fromBuffer(emptyBuf(1));
+const _statusVal = statusEnum.s; // type: "0" | "1" | "128" or similar
+
+// ===========================================================================
+// 3. Bitmap (via mapN)
+// ---------------------------------------------------------------------------
+// Each declared flag becomes a named boolean property. null padding is
+// filtered out. Inherited methods from BitmapBase are available.
+// ===========================================================================
+
+const StatusBitmap = DataTypes.map8("online", "lowBattery", "tampered");
+const status = StatusBitmap.fromBuffer(Buffer.from([0b00000101]), 0);
+
+// Named flag properties are typed as boolean.
+const _flagOnline: boolean = status.online;
+status.lowBattery = true;
+// @ts-expect-error unknown flag
+status.notAFlag;
+
+// Inherited methods still work.
+status.setBit(0, true);
+const _bit: boolean = status.getBit(0);
+const _allSet = status.getBits(); // returns Array of the declared flag union
+
+// null slots in a mapN are omitted from the type (runtime ignores them too).
+const Capabilities = DataTypes.map8(
+  "alternatePANCoordinator",
+  "deviceType",
+  "powerSourceMains",
+  "receiveWhenIdle",
+  null,
+  null,
+  "security",
+  "allocateAddress",
+);
+const caps = Capabilities.fromBuffer(emptyBuf(1));
+const _cap: boolean = caps.security;
+// @ts-expect-error "null" is not a valid property - null slots are filtered out
+caps.null;
+
+// ===========================================================================
+// 4. Struct basics - create, read, write, typo detection
+// ===========================================================================
+
+const ZdoEndDeviceAnnounce = Struct("ZdoEndDeviceAnnounce", {
+  srcAddr: DataTypes.uint16,
+  IEEEAddr: DataTypes.EUI64,
+});
+
+// Reading narrows field types.
+const zdo = ZdoEndDeviceAnnounce.fromBuffer(Buffer.from([0, 1, 2, 3]));
+const _zdoSrc: number = zdo.srcAddr;
+const _zdoIeee: string = zdo.IEEEAddr;
+// @ts-expect-error srcAddr is number, not string
+zdo.srcAddr.trim();
+
+// Writing accepts a plain object (not just a StructInstance).
+const zdoBuf = Buffer.alloc(8);
+ZdoEndDeviceAnnounce.toBuffer(zdoBuf, { srcAddr: 1, IEEEAddr: "abc" });
+
+// Typos in field names are rejected on write.
+ZdoEndDeviceAnnounce.toBuffer(zdoBuf, {
+  srcAddr: 1,
+  // @ts-expect-error typo in IEEEAddr
+  IEEAddr: "abc",
+});
+
+// Wrong field types are rejected.
+ZdoEndDeviceAnnounce.toBuffer(zdoBuf, {
+  // @ts-expect-error srcAddr must be number
+  srcAddr: "nope",
+  IEEEAddr: "abc",
+});
+
+// Instance helpers on the returned object.
+const _zdoJson = zdo.toJSON();
+const _zdoJsonSrc: number = _zdoJson.srcAddr;
+const _zdoWrite: Buffer = zdo.toBuffer();
+const _zdoWriteWithBuf: Buffer = zdo.toBuffer(Buffer.alloc(10), 0);
+
+// ===========================================================================
+// 5. Nested structs and arrays
+// ---------------------------------------------------------------------------
+// Regression coverage for "Structs in Structs" and "Array of Structs"
+// patterns (the former was listed as a limitation before this PR).
+// ===========================================================================
+
+const NetworkAddress = Struct("NetworkAddress", {
+  short: DataTypes.uint16,
+  ieee: DataTypes.EUI64,
+});
+
+const Endpoint = Struct("Endpoint", {
+  id: DataTypes.uint8,
+  profileId: DataTypes.uint16,
+  inputClusters: DataTypes.Array8(DataTypes.uint16),
+});
+
+const Device = Struct("Device", {
+  version: DataTypes.uint8,
+  address: NetworkAddress, // Struct-in-Struct
+  capabilities: Capabilities, // Bitmap field
+  supportedChannels: DataTypes.Array8(DataTypes.uint8), // Array of primitives
+  endpoints: DataTypes.Array8(Endpoint), // Array of Structs
+  // Triple nesting: Struct in Struct in Struct
+  gateway: Struct("Gateway", {
+    uplink: NetworkAddress,
+    downlink: NetworkAddress,
+  }),
+});
+
+const device = Device.fromBuffer(emptyBuf(256));
+
+// Field access narrows through every level.
+const _devVer: number = device.version;
+const _devShort: number = device.address.short;
+const _devIeee: string = device.address.ieee;
+const _devCap: boolean = device.capabilities.alternatePANCoordinator;
+const _devCh: number = device.supportedChannels[0];
+const _devEpId: number = device.endpoints[0].id;
+const _devEpCluster: number = device.endpoints[0].inputClusters[0];
+const _devGwIeee: string = device.gateway.uplink.ieee;
+
+// Typos are caught at every nesting level.
+// @ts-expect-error typo at level 1
+device.versoin;
+// @ts-expect-error typo inside nested struct
+device.address.shrt;
+// @ts-expect-error typo inside array element
+device.endpoints[0].profIleId;
+// @ts-expect-error typo in triple-nested field
+device.gateway.uplink.ie;
+
+// Wrong types caught at every level.
+// @ts-expect-error number to string
+const _wrongVer: string = device.version;
+// @ts-expect-error nested number to string
+const _wrongShort: string = device.address.short;
+
+// Writing accepts plain objects all the way down.
+Device.toBuffer(emptyBuf(256), {
+  version: 1,
+  address: { short: 0xabcd, ieee: "00:11:22:33:44:55:66:77" },
+  capabilities: caps, // Bitmap field requires a Bitmap instance at runtime
+  supportedChannels: [11, 15, 20, 25],
+  endpoints: [{ id: 1, profileId: 0x0104, inputClusters: [0, 6, 8] }],
+  gateway: {
+    uplink: { short: 0, ieee: "00:00:00:00:00:00:00:01" },
+    downlink: { short: 1, ieee: "00:00:00:00:00:00:00:02" },
+  },
+});
+
+// Wrong type at any nesting level is rejected.
+Device.toBuffer(emptyBuf(256), {
+  // @ts-expect-error wrong type for version
+  version: "not a number",
+  address: { short: 0, ieee: "" },
+  capabilities: caps,
+  supportedChannels: [],
+  endpoints: [],
+  gateway: {
+    uplink: { short: 0, ieee: "" },
+    downlink: { short: 0, ieee: "" },
+  },
+});
+
+// ===========================================================================
+// 6. fromBuffer returnLength overload
+// ---------------------------------------------------------------------------
+// When returnLength: true, the call returns `{ result, length }`.
+// When omitted or false, it returns the result directly.
+// ===========================================================================
+
+const withLen = ZdoEndDeviceAnnounce.fromBuffer(emptyBuf(10), 0, true);
+const _withLenLen: number = withLen.length;
+const _withLenSrc: number = withLen.result.srcAddr;
+
+const direct = ZdoEndDeviceAnnounce.fromBuffer(emptyBuf(10), 0);
+const _directSrc: number = direct.srcAddr;
+// @ts-expect-error direct result is the struct, no .length wrapper
+const _directLen: number = direct.length;
+
+// ===========================================================================
+// 7. StaticStruct metadata
+// ===========================================================================
+
+const _staticFields = ZdoEndDeviceAnnounce.fields;
+const _staticName: string = ZdoEndDeviceAnnounce.name;
+const _staticLen: number = ZdoEndDeviceAnnounce.length;
+
+// ===========================================================================
+// 8. encodeMissingFieldsBehavior option
+// ===========================================================================
+
+Struct("Opt1", { a: DataTypes.uint8 }, { encodeMissingFieldsBehavior: "skip" });
+Struct("Opt2", { a: DataTypes.uint8 }, { encodeMissingFieldsBehavior: "default" });
+// @ts-expect-error only "skip" or "default" is allowed
+Struct("OptBad", { a: DataTypes.uint8 }, { encodeMissingFieldsBehavior: "foo" });
+
+// ===========================================================================
+// 9. Custom DataType via exposed constructor
+// ---------------------------------------------------------------------------
+// The DataType class constructor is now exposed so consumers can define
+// their own types.
+// ===========================================================================
+
+const Uint16LE = new DataType<number>(
+  0xff,
+  "uint16LE",
+  2,
+  (buf, value, i) => buf.writeUInt16LE(value, i ?? 0),
+  (buf, i) => buf.readUInt16LE(i ?? 0),
+);
+const customStruct = Struct("Custom", { v: Uint16LE }).fromBuffer(emptyBuf(2));
+const _customV: number = customStruct.v;

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -146,6 +146,19 @@ const Status = DataTypes.enum8({ 0x00: 0, 0x01: 1, 0x80: 2 });
 const statusEnum = Struct("StatusEnum", { s: Status }).fromBuffer(emptyBuf(1));
 const _statusVal = statusEnum.s; // type: "0" | "1" | "128" or similar
 
+// It could occur that a device returns a value outside of the enum.
+// In this case fromBuffer returns undefined.
+const UndefinedEnum = DataTypes.enum4<"Valid" | 1 | undefined>({Valid: 0, 1: 1})
+const undefinedEnum = Struct("Undefined", {enum: UndefinedEnum}).fromBuffer(emptyBuf());
+const undefinedEnumFromBuffer: 1 | "Valid" | undefined = undefinedEnum.enum;
+// @ts-expect-error enum value could be undefined
+const undefinedEnumFromBufferWrong: 1 | "Valid" = undefinedEnum.enum;
+// @ts-expect-error undefined enum value cannot be written to buffer
+UndefinedEnum.toBuffer(emptyBuf(), undefined);
+const undefinedEnumDefault : 1 | "Valid" | undefined = UndefinedEnum.defaultValue
+// @ts-expect-error default enum value could be undefined
+const undefinedEnumDefaultWrong : 1 | "Valid" = UndefinedEnum.defaultValue
+
 // ===========================================================================
 // 3. Bitmap (via mapN)
 // ---------------------------------------------------------------------------

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -104,9 +104,11 @@ const _bufPlain: Buffer = bufs.b;
 const _buf8: Buffer = bufs.b8;
 const _buf16: Buffer = bufs.b16;
 
-// noData always returns null
+// noData always returns { result:null, length: 0 }
 const none = Struct("None", { n: DataTypes.noData }).fromBuffer(emptyBuf());
-const _noData: null = none.n;
+const _noData: null = none.n.result;
+// @ts-expect-error noData.fromBuffer always returns an object
+const _wrongNoData: null = DataTypes.noData.fromBuffer(emptyBuf());
 
 // ===========================================================================
 // 2. Enum narrowing

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -115,6 +115,14 @@ const _noData: null = none.n.result;
 // @ts-expect-error noData.fromBuffer always returns an object
 const _wrongNoData: null = DataTypes.noData.fromBuffer(emptyBuf());
 
+const normalToBufferReturn: number = DataTypes.bool.toBuffer(emptyBuf(), true);
+// @ts-expect-error toBuffer normally returns number
+const wrongNormalToBufferReturn: null = DataTypes.bool.toBuffer(emptyBuf(), true);
+
+const _noDataToBufferReturn: null = DataTypes.noData.toBuffer(emptyBuf(), "anything")
+// @ts-expect-error noData.toBuffer returns null
+const _wrongNoDataToBufferReturn: number = DataTypes.noData.toBuffer(emptyBuf(), "anything")
+
 // ===========================================================================
 // 2. Enum narrowing
 // ---------------------------------------------------------------------------

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -60,11 +60,11 @@ const datas = Struct("Datas", {
   d16: DataTypes.data16,
   d64: DataTypes.data64,
 }).fromBuffer(emptyBuf());
-const _dataD8: Buffer = datas.d8;
-const _dataD16: Buffer = datas.d16;
+const _dataD8: number = datas.d8;
+const _dataD16: number = datas.d16;
 const _dataD64: Buffer = datas.d64;
-// @ts-expect-error data8 is Buffer, not number
-const _dataD8Wrong: number = datas.d8;
+// @ts-expect-error data64 is Buffer, not number
+const _dataD64Wrong: number = datas.d64;
 
 // octstr returns Buffer, string returns string (octstr was incorrectly typed as string before)
 const strs = Struct("Strs", {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "target": "es2020",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "paths": {
+      "@athombv/data-types": ["./index.d.ts"]
+    }
+  },
+  "include": ["test/types-test.ts", "index.d.ts"]
+}


### PR DESCRIPTION
The data types did not yet reflect the actual type of data they contained, so I made the class definition generic and added a new DataTypes definition using it.

I also took the liberty to rewrite the other definitions based on the types we have built at @athombv/drenso, based on the JS source and runtime introspection.