### PR TITLE
chore: use npm run build --if-present in publish workflow

### DIFF
--- a/.github/workflows/publish-package-npm.yml
+++ b/.github/workflows/publish-package-npm.yml
@@ -63,13 +63,7 @@ jobs:
         run: npm ci --ignore-scripts --audit=false
 
       - name: Build
-        run: |
-          if jq --exit-status '(.scripts // {}) | has("build")' package.json > /dev/null; then
-            echo "Running npm run build..."
-            npm run build
-          else
-            echo "No build script; skipping."
-          fi
+        run: npm run build --if-present
 
       - name: Publish dry run
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary

Follow-up to #46. Replaces the jq guard around `npm run build` with npm's built-in `--if-present` flag.

## Test plan

- [x] Trigger workflow via `workflow_dispatch` and verify the Build step is a no-op (no build script in this repo)